### PR TITLE
Add Automated GPG Setup Script and Documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Ignore OS files
+.DS_Store
+Thumbs.db
+
+# Ignore temporary files
+*.tmp
+*.log
+
+# Ignore Markdown editor backup files
+*.md~
+*.markdown~
+*.bak
+
+# Ignore Mac system files
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Ignore Windows system files
+Desktop.ini
+Thumbs.db
+ehthumbs.db
+
+# Ignore Visual Studio Code workspace settings (if using VS Code)
+.vscode/
+
+# Ignore WSL-related temporary files
+*.swp
+
+# Ignore any other editor or IDE specific files
+.idea/
+*.sublime-*
+*.vscode/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
-# GPG-signed-commits-setup
-This project provides a complete guide on configuring GPG for signing commits on Linux &amp; Windows. It walks through the setup of GPG keys, configuring Git to use these keys for commit signatures, and verifying signed commits on GitHub. This guide aims to improve code authenticity and security by ensuring commit authorship verification.
+# GPG Signed Commits Setup Guide
+
+## Introduction
+GPG Signed Commits are a way to verify the authenticity of commits in Git, ensuring the integrity of the code and proving that the commit was made by the rightful author.
+
+This guide will help you set up GPG signed commits for GitHub, whether you're using Linux, Windows, or WSL (Windows Subsystem for Linux).
+
+## Setup Guides
+- [Linux Setup (WSL)](docs/linux-setup.md)
+- [Windows Setup](docs/windows-setup.md)
+
+## Prerequisites
+- Git
+- GPG (GNU Privacy Guard)
+
+## Troubleshooting
+If you encounter any issues, check out the [Troubleshooting Guide](docs/troubleshooting.md).

--- a/README.md
+++ b/README.md
@@ -8,10 +8,8 @@ This guide will help you set up GPG signed commits for GitHub, whether you're us
 ## Setup Guides
 - [Linux Setup (WSL)](docs/linux-setup.md)
 - [Windows Setup](docs/windows-setup.md)
+- [Running the Setup Script](docs/run-setup-script.md)
 
 ## Prerequisites
 - Git
 - GPG (GNU Privacy Guard)
-
-## Troubleshooting
-If you encounter any issues, check out the [Troubleshooting Guide](docs/troubleshooting.md).

--- a/docs/linux-setup.md
+++ b/docs/linux-setup.md
@@ -1,0 +1,138 @@
+# Linux (WSL) Setup Guide for GPG Signed Commits
+
+## Prerequisites
+Before setting up GPG signed commits on Linux (WSL), ensure you have the following installed:
+
+- [Git](https://git-scm.com/)
+- [GPG (GNU Privacy Guard)](https://gnupg.org/)
+- [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install) installed and running
+
+### Step 1: Install Git and GPG on WSL
+If you haven’t installed Git and GPG on your WSL distribution yet, follow these steps to install them.
+
+1. Open your **WSL terminal**.
+2. Update the package list and install Git and GPG:
+
+    ```sh
+    sudo apt update
+    sudo apt install git gnupg
+    ```
+
+3. Verify that Git and GPG are installed by running:
+
+    ```sh
+    git --version
+    gpg --version
+    ```
+
+    You should see the version details for both Git and GPG.
+
+### Step 2: Generate Your GPG Key
+Now you’ll create a GPG key pair to use for signing your commits.
+
+1. Run the following command to generate your GPG key:
+
+    ```sh
+    gpg --full-generate-key
+    ```
+
+2. Choose the default key type (1) for RSA and RSA.
+
+3. Select 4096 bits for the key size `(this is more secure)`.
+
+4. Set the expiration date for your key `(optional)`. You can leave it blank for no expiration.
+
+5. Enter your name and email address. Ensure the email you provide matches the one you use on GitHub.
+
+6. Set a passphrase to protect your key. This adds an extra layer of security. `Optional: you can leave it blank to use passwordless`
+
+### Step 3: List Your GPG Keys
+Once the key is created, you need to find the key ID to configure Git.
+
+1. Run the following command to list all your GPG keys:
+
+    ```sh
+    gpg --list-secret-keys --keyid-format LONG
+    ```
+
+2. You will see something like this:
+
+    ```sh
+    /Users/you/.gnupg/secring.gpg
+    ------------------------------
+    sec   4096R/<Your-Key-ID> 2019-09-12 [expires: 2020-09-12]
+    uid                          Your Name <youremail@example.com>
+    ssb   4096R/<Your-Subkey-ID> 2019-09-12
+    ```
+
+3. Copy the long key ID (the string after `4096R/`), which you’ll use in the next steps.
+
+### Step 4: Configure Git to Use Your GPG Key
+Now, let’s configure Git to use your GPG key for signing commits.
+
+1. Set the key in your global Git configuration:
+
+    ```sh
+    git config --global user.signingkey <Your-Key-ID>
+    ```
+
+    Replace `<Your-Key-ID>` with the key ID you copied earlier.
+
+2. Enable commit signing by default:
+
+    ```sh
+    git config --global commit.gpgSign true
+    ```
+
+### Step 5: Add Your GPG Key to GitHub
+To have your signed commits verified on GitHub, you need to add your GPG key to your GitHub account.
+
+1. Export your public key with the following command:
+
+    ```sh
+    gpg --armor --export <Your-Key-ID>
+    ```
+    This will output your public key in ASCII format. Copy the entire output, including the `-----BEGIN PGP PUBLIC KEY BLOCK-----` and `-----END PGP PUBLIC KEY BLOCK-----` lines.
+
+2. Go to your [GitHub GPG keys settings](https://github.com/settings/keys).
+
+3. Click New GPG key, then paste your copied public key into the provided field and click Add GPG key.
+
+### Step 6: Test GPG Signed Commits
+Now that you’ve set everything up, let’s test it by making a signed commit.
+
+1. Make a change to a repository and stage the changes:
+
+    ```sh
+    git add .
+    ```
+
+2. Commit the changes with a message:
+
+    ```sh
+    git commit -m "Test GPG signed commit"
+    ```
+
+3. Push the commit to GitHub:
+
+    ```sh
+    git push origin main
+    ```
+
+4. Visit your GitHub repository and verify that the commit shows as `Verified`.
+
+## Troubleshooting
+If your commit does not show as "`Verified`" on GitHub, try the following:
+
+- Ensure your email matches on GitHub and in GPG: The email address associated with your GPG key must match the one used in your GitHub account.
+- Verify GPG is working correctly: Run `gpg --list-keys` to ensure your key is available.
+- Check GPG passphrase: If you are prompted for the passphrase when making a commit, ensure it is entered correctly.
+
+
+## Key Sections in This Guide:
+- **Install GPG and Git**: Step-by-step instructions for installing and verifying GPG and Git on WSL.
+- **Generating and Configuring Keys**: How to generate a GPG key and configure Git to use it for commit signing.
+- **Adding the Key to GitHub**: Detailed instructions for adding your GPG key to your GitHub account.
+- **Troubleshooting**: Solutions to common issues that may arise during setup.
+
+This guide should provide users with everything they need to configure GPG signed commits on Linux via WSL, ensuring that their commits are verified on GitHub.

--- a/docs/run-setup-script.md
+++ b/docs/run-setup-script.md
@@ -1,0 +1,44 @@
+# Running the GPG Signed Commits Setup Script
+
+This guide will walk you through how to run the `setup-gpg-signed-commits.sh` script to automatically set up GPG signed commits in your Git environment.
+
+## Running the Script
+The script automates the setup of GPG signed commits. To run the script, follow these steps:
+
+### Step 1: Clone the Repository
+If you haven't already, clone the repository where the script is hosted:
+
+```sh
+git clone https://github.com/CloudAutomation-Hub/GPG-signed-commits-setup.git
+```
+
+### Step 2: Make the Script Executable
+Ensure that the script has executable permissions. You can do this by running:
+
+```sh
+chmod +x setup-gpg-signed-commits.sh
+```
+
+### Step 3: Execute the Script
+Run the script with the following command:
+
+```sh
+./setup-gpg-signed-commits.sh
+```
+
+### Step 4: Follow the Prompts
+The script will guide you through the setup process. You'll be prompted for the following:
+
+1. **GPG Key ID:** If you already have a GPG key, provide the key ID. If you don't have one, the script will help you generate it.
+
+2. **GitHub Key Addition:** The script will automatically open your default web browser and take you to the GitHub GPG keys page to add your public GPG key. If the browser doesn’t open, you'll be provided with a URL to open manually.
+
+3. **Test Commit:** After setting up, the script will attempt to make a test commit to ensure that everything is working correctly.
+
+### Step 5: Verify the Setup
+Once the script completes, go to your GitHub account and verify that the commit is marked as "`Verified`" on the test repository.
+
+## Troubleshooting
+- **xdg-open:** command not found: If you're using WSL or Linux and the browser does not open automatically, you can manually open the GitHub GPG keys page by navigating to [GitHub GPG Keys Settings](https://github.com/settings/keys).
+
+- **GPG Key Not Found:** If the script can't find your GPG key, make sure you've generated it and that you're using the correct key ID.

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -21,7 +21,7 @@ Download and install **GPG for Windows** from the official site.
     gpg --version
     ```
 
-    You should see the version of GPG installed on your system.
+You should see the version of GPG installed on your system.
 
 ### Step 3: Generate Your GPG Key
 Now, you’ll need to create a GPG key pair that will be used for signing your commits.
@@ -59,7 +59,7 @@ You should see output similar to this:
     ssb   4096R/<Your-Subkey-ID> 2019-09-12
     ```
 
-The long key ID is the value following 4096R/. Copy the entire key ID (<Your-Key-ID>) to use in the next step.
+The long key ID is the value following `4096R/`. Copy the entire key ID (`<Your-Key-ID>`) to use in the next step.
 
 ### Step 5: Configure Git to Use Your GPG Key
 Now that you have your GPG key, configure Git to use it for signing commits:

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -17,7 +17,7 @@ Download and install **GPG for Windows** from the official site.
 - Follow the installation prompts to install GPG.
 - After installation, verify that GPG is installed correctly by opening the **Command Prompt** and running:
 
-    ````sh
+    ```sh
     gpg --version
     ```
 

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -126,3 +126,7 @@ If your commit does not show as "`Verified`" on GitHub, try the following:
 - **Q: How do I remove my GPG key from GitHub?** A: Go to GitHub's GPG settings and click the Delete button next to the key you wish to remove.
 
 - **Q: Can I use my GPG key across multiple computers?** A: Yes, as long as you export and import your GPG key on all your devices and configure Git to use the same key ID.
+
+---
+
+That's it! You've successfully set up GPG signed commits on Windows. Now your commits will be cryptographically signed, ensuring they’re verifiable and tamper-proof.

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -45,19 +45,19 @@ Now, you’ll need to create a GPG key pair that will be used for signing your c
 ### Step 4: List Your GPG Keys
 Once the key is created, you need to find the key ID to configure Git. Run the following command to list your keys:
 
-    ```sh
-    gpg --list-secret-keys --keyid-format LONG
-    ```
+```sh
+gpg --list-secret-keys --keyid-format LONG
+```
 
 You should see output similar to this:
 
-    ```sh
-    /Users/you/.gnupg/secring.gpg
-    ------------------------------
-    sec   4096R/<Your-Key-ID> 2019-09-12 [expires: 2024-09-12]
-    uid                          Your Name <youremail@example.com>
-    ssb   4096R/<Your-Subkey-ID> 2019-09-12
-    ```
+```sh
+/Users/you/.gnupg/secring.gpg
+------------------------------
+sec   4096R/<Your-Key-ID> 2019-09-12 [expires: 2024-09-12]
+uid                          Your Name <youremail@example.com>
+ssb   4096R/<Your-Subkey-ID> 2019-09-12
+```
 
 The long key ID is the value following `4096R/`. Copy the entire key ID (`<Your-Key-ID>`) to use in the next step.
 

--- a/docs/windows-setup.md
+++ b/docs/windows-setup.md
@@ -1,0 +1,128 @@
+# Windows Setup Guide for GPG Signed Commits
+
+## Prerequisites
+Before setting up GPG signed commits on Windows, ensure you have the following installed:
+
+- [Git for Windows](https://gitforwindows.org/)
+- [GPG (GNU Privacy Guard)](https://gnupg.org/)
+
+### Step 1: Install Git for Windows
+If you haven’t installed Git on your system yet, download and install **Git for Windows** from the link provided.
+
+- During installation, **ensure that you select "Use Git from the Windows Command Prompt"** for easier access to Git commands.
+
+### Step 2: Install GPG (GNU Privacy Guard)
+Download and install **GPG for Windows** from the official site.
+
+- Follow the installation prompts to install GPG.
+- After installation, verify that GPG is installed correctly by opening the **Command Prompt** and running:
+
+    ````sh
+    gpg --version
+    ```
+
+    You should see the version of GPG installed on your system.
+
+### Step 3: Generate Your GPG Key
+Now, you’ll need to create a GPG key pair that will be used for signing your commits.
+
+1. Open Git Bash (or the Windows Command Prompt) and run the following command to start the GPG key generation process:
+
+    ```sh
+    gpg --full-generate-key
+    ```
+
+2. You will be prompted to select the key type. Choose the default option (1) for RSA and RSA.
+
+3. When prompted for the key size, choose 2048 bits or 4096 bits (4096 bits is more secure).
+
+4. Set an expiration date for your key `(optional)`. If you prefer no expiration, just press Enter to skip.
+
+5. Enter your name and email address. Make sure the email matches the one you use on GitHub.
+
+6. Enter a passphrase to protect your key. This adds an extra layer of security. `Optional: you can leave it blank to use passwordless`
+
+### Step 4: List Your GPG Keys
+Once the key is created, you need to find the key ID to configure Git. Run the following command to list your keys:
+
+    ```sh
+    gpg --list-secret-keys --keyid-format LONG
+    ```
+
+You should see output similar to this:
+
+    ```sh
+    /Users/you/.gnupg/secring.gpg
+    ------------------------------
+    sec   4096R/<Your-Key-ID> 2019-09-12 [expires: 2024-09-12]
+    uid                          Your Name <youremail@example.com>
+    ssb   4096R/<Your-Subkey-ID> 2019-09-12
+    ```
+
+The long key ID is the value following 4096R/. Copy the entire key ID (<Your-Key-ID>) to use in the next step.
+
+### Step 5: Configure Git to Use Your GPG Key
+Now that you have your GPG key, configure Git to use it for signing commits:
+
+1. Set the key in your global Git configuration:
+
+    ```sh
+    git config --global user.signingkey <Your-Key-ID>
+    ```
+
+    Replace <Your-Key-ID> with the key ID you obtained from the previous step.
+
+2. Enable commit signing by default:
+
+    ```sh
+    git config --global commit.gpgSign true
+    ```
+
+### Step 6: Add Your GPG Key to GitHub
+To sign your commits on GitHub, you need to add your GPG key to your GitHub account:
+
+1. Export your public key with the following command:
+
+    ```sh
+    gpg --armor --export <Your-Key-ID>
+    ```
+
+    This will output your public key in ASCII format. Copy the entire output (including `-----BEGIN PGP PUBLIC KEY BLOCK-----` and `-----END PGP PUBLIC KEY BLOCK-----`).
+
+2. Go to your [GitHub GPG keys settings](https://github.com/settings/keys).
+
+3. Click New GPG key, then paste your copied public key into the provided field and click Add GPG key.
+
+### Step 7: Test GPG Signed Commits
+Now, you’re ready to test your GPG setup by making a commit:
+
+1. Make a change to a repository and stage it:
+    ```sh
+    git add .
+    ```
+
+2. Commit the change with a message:
+
+    ```sh
+    git commit -m "Test GPG signed commit"
+    ```
+
+3. Push your commit to GitHub:
+
+    ```sh
+    git push origin main
+    ```
+
+4. Go to your GitHub repository and confirm that the commit shows as Verified.
+
+## Troubleshooting
+If your commit does not show as "`Verified`" on GitHub, try the following:
+
+- Ensure your email matches on GitHub and in GPG: The email address associated with your GPG key should match the one used in your GitHub account.
+- Verify GPG is working correctly: Run `gpg --list-keys` to ensure your key is available.
+- Check GPG passphrase: If you're prompted for the passphrase when making a commit, ensure it’s entered correctly.
+
+## FAQ
+- **Q: How do I remove my GPG key from GitHub?** A: Go to GitHub's GPG settings and click the Delete button next to the key you wish to remove.
+
+- **Q: Can I use my GPG key across multiple computers?** A: Yes, as long as you export and import your GPG key on all your devices and configure Git to use the same key ID.

--- a/scripts/setup-gpg-signed-commits.sh
+++ b/scripts/setup-gpg-signed-commits.sh
@@ -1,0 +1,99 @@
+#!/bin/bash
+
+# Automated GPG Signed Commits Setup Script
+
+# Function to check if a command exists
+command_exists() {
+    command -v "$1" &> /dev/null
+}
+
+# Step 1: Install Git and GPG if not already installed
+echo "Checking if Git and GPG are installed..."
+
+# Check if Git is installed
+if ! command_exists git; then
+    echo "Git not found! Installing Git..."
+    sudo apt update && sudo apt install -y git
+else
+    echo "Git is already installed."
+fi
+
+# Check if GPG is installed
+if ! command_exists gpg; then
+    echo "GPG not found! Installing GPG..."
+    sudo apt install -y gnupg
+else
+    echo "GPG is already installed."
+fi
+
+# Step 2: Generate GPG key if not already created
+echo "Checking if GPG key exists..."
+
+# List existing GPG keys
+existing_key=$(gpg --list-secret-keys --keyid-format LONG)
+
+if [[ -z "$existing_key" ]]; then
+    echo "No GPG key found! Generating a new key..."
+
+    # Generate a new GPG key
+    gpg --full-generate-key
+
+    # Wait for key generation
+    echo "Please follow the prompts to generate your GPG key."
+else
+    echo "GPG key already exists."
+fi
+
+# Step 3: Set up Git configuration to use GPG key
+echo "Configuring Git to use GPG key for signing commits..."
+
+# Get GPG key ID
+GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format LONG | grep sec | awk '{print $2}' | sed 's/\/.*//')
+
+if [[ -z "$GPG_KEY_ID" ]]; then
+    echo "No GPG key found. Exiting setup."
+    exit 1
+else
+    echo "Using GPG key ID: $GPG_KEY_ID"
+    # Configure Git to use the GPG key
+    git config --global user.signingkey "$GPG_KEY_ID"
+    git config --global commit.gpgSign true
+fi
+
+# Step 4: Export the GPG key to be added to GitHub
+echo "Exporting GPG public key..."
+
+gpg --armor --export "$GPG_KEY_ID" > ~/gpg-public-key.asc
+
+echo "Please copy the following GPG key and add it to your GitHub account under Settings > SSH and GPG keys > New GPG key:"
+cat ~/gpg-public-key.asc
+
+# Step 5: Ask user to confirm addition of the GPG key to GitHub
+echo "Do you want to open GitHub to add the key now? (y/n)"
+read -r open_github
+
+if [[ "$open_github" == "y" ]]; then
+    if command_exists xdg-open; then
+        xdg-open "https://github.com/settings/keys"
+    else
+        echo "Opening GitHub in your default browser. Please add the GPG key manually."
+        cmd.exe /C start "https://github.com/settings/keys"
+    fi
+else
+    echo "Please manually visit https://github.com/settings/keys and add the GPG key."
+fi
+
+# Step 6: Verify the GPG setup and test signed commit
+echo "Testing GPG signed commit..."
+
+# Create a test commit
+git init test-repo
+cd test-repo
+echo "Testing GPG signed commit" > test-file.txt
+git add test-file.txt
+git commit -m "Test GPG signed commit"
+
+echo "If everything was set up correctly, this commit should be signed and verified on GitHub."
+
+# End of the script
+echo "GPG signed commit setup complete!"


### PR DESCRIPTION
This PR introduces a script for automating the setup of GPG for signed commits. The script streamlines the process for configuring GPG keys and enabling commit signing for both Windows (WSL) and Linux users. Additionally, documentation has been added to guide users through the setup process, including instructions for using the automated script.

### Changes Included:
- Added `setup-gpg-signed-commits.sh` script to automate GPG key generation and Git configuration for signed commits.
- Created documentation for setting up GPG signed commits for Windows and Linux (WSL) users.
- Added troubleshooting guide for common setup issues.

### How to Test:
- Follow the setup instructions in the documentation for your operating system.
- Run the setup script to automate the GPG configuration.
- Test GPG signing by making a commit and verifying the signature on GitHub.
